### PR TITLE
Fix field name on #refund

### DIFF
--- a/lib/workarea/paypal/gateway.rb
+++ b/lib/workarea/paypal/gateway.rb
@@ -90,7 +90,7 @@ module Workarea
           request.request_body(
             amount: {
               value: amount.to_s,
-              currency: amount.currency.iso_code
+              currency_code: amount.currency.iso_code
             }
           )
         end


### PR DESCRIPTION
This change was required for Paypal during the test in staging of the Spelldesings project.