### PR TITLE
Pass BN code in button_source on gateway initialization

### DIFF
--- a/lib/workarea/paypal.rb
+++ b/lib/workarea/paypal.rb
@@ -15,7 +15,9 @@ module Workarea
     def self.auto_configure_gateway
       if Rails.application.secrets.paypal.present?
         self.gateway = ActiveMerchant::Billing::PaypalExpressGateway.new(
-          Rails.application.secrets.paypal.deep_symbolize_keys
+          Rails.application.secrets.paypal.deep_symbolize_keys.merge(
+            button_source: 'Workarea_SP'
+          )
         )
       elsif gateway.blank?
         self.gateway = ActiveMerchant::Billing::BogusGateway.new


### PR DESCRIPTION
ActiveMerchant should be using the application_id class attribute
of the gateway but improperly references it. As an alternative you
can pass the BN code as button_source when initializing the gateway,
which works as expected.