### PR TITLE
Load JavaScript From PayPal Asynchronously

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-gem 'workarea'
+gem 'workarea', github: 'workarea-commerce/workarea', branch: 'v3.5-stable'

--- a/app/assets/javascripts/workarea/storefront/paypal/modules/paypal.js
+++ b/app/assets/javascripts/workarea/storefront/paypal/modules/paypal.js
@@ -1,0 +1,63 @@
+/**
+ *
+ * Reliably ensure that the PayPal SDK is either loaded or will
+ * be loading.
+ *
+ * @namespace WORKAREA.paypal
+ */
+WORKAREA.registerModule('paypal', (function () {
+    'use strict';
+
+    var handlers = [],
+        attempts = 0,
+        paypalLoaded = null,
+
+        /**
+         * Define a function that will be called when the paypal SDK has
+         * loaded.
+         *
+         * @method
+         * @name ready
+         * @param function handler - A function to be called when PayPal
+         *                           is available.
+         * @memberof WORKAREA.paypal
+         */
+        ready = function(handler) {
+            if (paypalLoaded) {
+                handler();
+            } else {
+                handlers.push(handler);
+            }
+        },
+
+        /**
+         * Continuously check for whether the Paypal SDK has loaded
+         * every 5 seconds, and call function handlers defined in
+         * `ready()` when the `window.paypal` object is available. This
+         * will only occur if the `<script>` tag containing the PayPal
+         * SDK is detected to be on the page.
+         *
+         * @method
+         * @name init
+         * @memberof WORKAREA.paypal
+         */
+        init = function() {
+            var $sdk = $('script[data-partner-attribution-id]'),
+                paypalExpectedToLoad = !_.isEmpty($sdk);
+
+            attempts += 1;
+            paypalLoaded = window.paypal !== undefined;
+
+            if (!paypalLoaded && paypalExpectedToLoad && attempts <= 20) {
+                window.setTimeout(init, 2000);
+            } else if (paypalLoaded) {
+                _.each(handlers, function(handler) { handler(); });
+                handlers = [];
+            }
+        };
+
+    return {
+        ready: ready,
+        init: init
+    };
+}()));

--- a/app/assets/javascripts/workarea/storefront/paypal/modules/paypal_buttons.js
+++ b/app/assets/javascripts/workarea/storefront/paypal/modules/paypal_buttons.js
@@ -56,13 +56,14 @@ WORKAREA.registerModule('paypalButtons', (function () {
          * @name init
          * @memberof WORKAREA.paypalButtons
          */
-        init = function ($scope) {
-            var $buttonContainer = $('#paypal-button-container', $scope);
+        init = function($scope) {
+            WORKAREA.paypal.ready(function() {
+                var $buttonContainer = $('#paypal-button-container', $scope);
 
-            if (window.paypal === undefined) { return; }
-            if (_.isEmpty($buttonContainer)) { return; }
+                if (_.isEmpty($buttonContainer)) { return; }
 
-            setup($buttonContainer);
+                setup($buttonContainer);
+            });
         };
 
     return {

--- a/app/assets/javascripts/workarea/storefront/paypal/modules/paypal_hosted_fields.js
+++ b/app/assets/javascripts/workarea/storefront/paypal/modules/paypal_hosted_fields.js
@@ -81,13 +81,14 @@ WORKAREA.registerModule('paypalHostedFields', (function () {
          * @memberof WORKAREA.paypalHostedFields
          */
         init = function ($scope) {
-            var $placeholder = $('[data-paypal-hosted-fields]', $scope);
+            WORKAREA.paypal.ready(function () {
+                var $placeholder = $('[data-paypal-hosted-fields]', $scope);
 
-            if (_.isEmpty($placeholder)) {  return;  }
-            if (window.paypal === undefined) { return; }
-            if (!paypal.HostedFields.isEligible()) { return; }
+                if (_.isEmpty($placeholder)) {  return;  }
+                if (!paypal.HostedFields.isEligible()) { return; }
 
-            setup($placeholder, $scope);
+                setup($placeholder, $scope);
+            });
         };
 
     return {

--- a/app/helpers/workarea/storefront/paypal_helper.rb
+++ b/app/helpers/workarea/storefront/paypal_helper.rb
@@ -27,6 +27,7 @@ module Workarea
 
         javascript_include_tag(
           "https://www.paypal.com/sdk/js?#{params.to_query}",
+          async: true,
           data: {
             partner_attribution_id: 'Workarea_SP_PCP', # Do not change this
             client_token: @paypal_client_token

--- a/config/initializers/append_points.rb
+++ b/config/initializers/append_points.rb
@@ -25,6 +25,7 @@ Workarea::Plugin.append_javascripts(
 
 Workarea::Plugin.append_javascripts(
   'storefront.modules',
+  'workarea/storefront/paypal/modules/paypal',
   'workarea/storefront/paypal/modules/update_checkout_submit_text',
   'workarea/storefront/paypal/modules/paypal_buttons',
   'workarea/storefront/paypal/modules/paypal_hosted_fields'


### PR DESCRIPTION
<img width="1218" alt="Screen Shot 2020-07-22 at 12 57 23 PM" src="https://user-images.githubusercontent.com/113026/88205525-ed429080-cc1a-11ea-8b5c-7b8894348549.png">

Using the `async` attribute in the `<script>` tag that loads PayPal's JavaScript code, Workarea can now prevent it blocking the page in case of a failure, and improve load time performance to boot.

Fixes #10 