### PR TITLE
Fix Typo in PayPal Environment

### DIFF
--- a/config/initializers/workarea.rb
+++ b/config/initializers/workarea.rb
@@ -10,7 +10,7 @@ Workarea.configure do |config|
   #
   config.paypal_environment =
     if Rails.env.production?
-      'Paypal::LiveEnvironment'
+      'PayPal::LiveEnvironment'
     else
       'PayPal::SandboxEnvironment'
     end


### PR DESCRIPTION
The `Workarea.config.paypal_environment` setting is constantized in order to load the correct class for that environment. A missing case caused the constantization to error out in the gateway and cause 500 errors on production.